### PR TITLE
Enable altering more settings through environment variables

### DIFF
--- a/Docker/Backend/appsettings.json
+++ b/Docker/Backend/appsettings.json
@@ -1,7 +1,7 @@
 {
   // Database configuration
   "ConnectionStrings": {
-    "SqlServer": "$DB_MSSQL"
+    "$DB_TYPE": "$DB_MSSQL"
     //"SQLite": "Data Source=:memory:"
     //"SQLite": "Data Source=Regard.db",
     //"Postgres": "User ID=root;Password=myPassword;Host=localhost;Port=5432;Database=myDataBase;Pooling=true;Min Pool Size=0;Max Pool Size=100;Connection Lifetime=0;"
@@ -10,7 +10,7 @@
 
   // Authentication encryption secret, change this to any random string
   "JWT": {
-    "Secret": "ThisIsMySecretuiq34yt089htdlkrgnsope4ht;dgnpo54uin"
+    "Secret": "$REGARD_JWT_SECRET"
   },
 
   // Directory where application data will be stored

--- a/Docker/Backend/entry.sh
+++ b/Docker/Backend/entry.sh
@@ -1,7 +1,10 @@
+#!/usr/bin/env bash
 envsubst < /etc/regard/appsettings.json > ./appsettings.json
 
 # wait for db
-SERVER=$( echo "$DB_MSSQL" | sed 's/;/\n/g' | grep Server= | cut -c 8- | sed 's/,/:/' )
-./wait-for-it.sh $SERVER
+if [ $DB_TYPE == "SqlServer" ]; then
+	SERVER=$( echo "$DB_MSSQL" | sed 's/;/\n/g' | grep Server= | cut -c 8- | sed 's/,/:/' )
+	./wait-for-it.sh $SERVER
+fi
 
 dotnet Regard.Backend.dll

--- a/Dockerfile.Backend
+++ b/Dockerfile.Backend
@@ -21,6 +21,8 @@ RUN apt-get update && \
 RUN useradd -ms /bin/bash regard
 
 ENV DB_MSSQL ""
+ENV DB_TYPE "SqlServer"
+ENV REGARD_JWT_SECRET "ThisIsMySecretuiq34yt089htdlkrgnsope4ht;dgnpo54uin"
 ENV REGARD_DATA_DIR "/data"
 ENV REGARD_DOWNLOAD_DIR "/data/download"
 ENV REGARD_MIGRATE 1

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ There are 3 things needed for Regard to work:
 - the backend `chibicitiberiu/regard-backend:latest`. For the backend, you need to setup the following environment variables:
 
   - `DB_MSSQL` - contains the Microsoft SQL connection string
+  - `REGARD_JWT_SECRET` - Signing key for user authentication tokens. This should be a long, random, alphanumeric string. If in dout, [use this handy website](https://www.grc.com/passwords.htm) to generate one.
   - `REGARD_DATA_DIR` - data directory that will be used for storing application data. This directory should be mounted as a volume to prevent data loss. Default: `/data/`
   - `REGARD_DOWNLOAD_DIR` - directory where videos downloads will be stored. This directory should be mounted as a volume to prevent data loss. Default: `/data/downloads` 
 


### PR DESCRIPTION
Enable altering more settings through environment variables. Namely the database type (which currently only works when set to the default, `SqlServer`) and the JWT signing token, which should always be set to a custom value when installing Regard.